### PR TITLE
Fix project filter buttons (replace & with and)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -115,12 +115,12 @@ sections:
       buttons:
         - name: All
           tag: '*'
-        - name: AI & LLM Systems
-          tag: AI & LLM Systems
+        - name: AI and LLM Systems
+          tag: AI and LLM Systems
         - name: Digital Interventions
           tag: Digital Interventions
-        - name: Re- & Upskilling
-          tag: Re- & Upskilling
+        - name: Re- and Upskilling
+          tag: Re- and Upskilling
     design:
       # Choose how many columns the section has. Valid values: '1' or '2'.
       columns: '1'

--- a/content/project/LOOM/index.md
+++ b/content/project/LOOM/index.md
@@ -2,7 +2,7 @@
 title: Learning Objective and Outcome Manager (LOOM)
 summary: 
 tags:
-  - AI & LLM Systems
+  - AI and LLM Systems
 date: '2016-06-01'
 
 # Optional external URL for project (replaces project detail page).

--- a/content/project/SCESC/index.md
+++ b/content/project/SCESC/index.md
@@ -2,7 +2,7 @@
 title: Swiss Circular Economy of Skills and Competences (SCESC)
 summary: This project promotes an unprecedented learning experience for advanced trainers, who are to be supported in an integrated manner with the help of a platform based on the circular economy model. The objectives of this project include the promotion of current and medium-term qualification needs, the full utilization of the competence portfolio of the trainee, which is realized with the help of a continuous comparison of individual qualification needs and advanced training opportunities, as well as the support of individual competence development by a digital coach. The project ran for approximately four years, from February 2022 to December 2025. Dr. Roman Rietsche was the overall project manager.
 tags:
-  - Re- & Upskilling
+  - Re- and Upskilling
 date: '2022-02-01'
 
 # Optional external URL for project (replaces project detail page).

--- a/content/project/belearn_digital_coach/index.md
+++ b/content/project/belearn_digital_coach/index.md
@@ -2,7 +2,7 @@
 title: "BeLEARN: Conversational AI-Driven Coach"
 summary: "Built and deployed a GPT-based Socratic tutor for a university statistics course, comparing tutoring strategies and deriving design guidelines for controllable LLM-based educational coaching systems. Funded by BeLEARN."
 tags:
-  - AI & LLM Systems
+  - AI and LLM Systems
 date: '2025-01-01'
 
 external_link: ''

--- a/content/project/brändi_digital_skills/index.md
+++ b/content/project/brändi_digital_skills/index.md
@@ -2,7 +2,7 @@
 title: "Brandi Digital Skills"
 summary: "Collaborated with Stiftung Brandi to systematically develop digital skill profiles, create a Role-Skill-Matrix based on the DigiComp framework, and design targeted re- and upskilling programs for employees in the social sector."
 tags:
-  - Re- & Upskilling
+  - Re- and Upskilling
 date: '2023-01-01'
 
 external_link: ''

--- a/content/project/digit_bot/index.md
+++ b/content/project/digit_bot/index.md
@@ -2,7 +2,7 @@
 title: DigiBot
 summary: DigiBot leverages AI to personalize digital skills assessments by adapting standardized questions to individual user profiles, enhancing relevance and engagement while balancing clarity and complexity for diverse skill levels.
 tags:
-  - AI & LLM Systems
+  - AI and LLM Systems
 date: '2024-01-01'
 
 # Optional external URL for project (replaces project detail page).


### PR DESCRIPTION
## Summary
- The `&` character in tag names breaks Wowchemy's Isotope.js CSS selector filtering
- Replace `&` with `and` in all tags: `AI and LLM Systems`, `Re- and Upskilling`
- Filter buttons and project tags now match correctly