### PR TITLE
Website improvements: quick fixes, HAIS Lab branding, pub cross-links

### DIFF
--- a/config/_default/hugo.yaml
+++ b/config/_default/hugo.yaml
@@ -4,7 +4,7 @@
 # This file is formatted using YAML syntax - learn more at https://learnxinyminutes.com/docs/yaml/
 
 title: Roman Rietsche # Website name
-baseURL: 'romanrietsche.github.io' # Website URL
+baseURL: 'https://romanrietsche.github.io/' # Website URL
 
 ############################
 ## LANGUAGE
@@ -30,7 +30,7 @@ module:
 ## ADVANCED
 ############################
 
-enableGitInfo: false
+enableGitInfo: true
 summaryLength: 30
 pagination:
   pagerSize: 10

--- a/config/_default/menus.yaml
+++ b/config/_default/menus.yaml
@@ -7,27 +7,24 @@ main:
   - name: Home
     url: '#about'
     weight: 10
-  - name: Experience
-    url: '#experience'
-    weight: 20
   - name: Projects
     url: '#projects'
-    weight: 30
+    weight: 20
   - name: Talks/Events
     url: '#talks'
-    weight: 40
+    weight: 30
   - name: Research Methods
     url: '#research'
-    weight: 50
+    weight: 40
   - name: Publications
     url: '#publications'
-    weight: 60
+    weight: 50
   - name: Teaching
     url: '#teaching'
-    weight: 70
+    weight: 60
   - name: Contact
     url: '#contact'
-    weight: 80
+    weight: 70
 
 # Link to a PDF of your resume/CV from the menu.
 # To enable, copy your resume/CV to `static/uploads/resume.pdf` and uncomment the lines below.

--- a/content/_index.md
+++ b/content/_index.md
@@ -46,12 +46,12 @@ sections:
               Research Interests:
               1. Developing effective information systems that embed artificial intelligence and large language models.
               2. Designing and measuring behavior change through digital interventions.
-              3. Evaluating the impact of digital technologies on organizations in the context of reskilling and upskilling 
-            
-              Head of Research Lab for AI-based re- and upskilling (LAIRU) 
-                * Development of AI tools e.g.: for digital onboarding, personalized learning paths, automated situative judgement tests
-                * Design of a holistic Human Centric Re- and Upskilling Framework for organizations
-                * Consulting
+              3. Evaluating the impact of digital technologies on organizations in the context of reskilling and upskilling
+
+              Head of [HAIS Lab](https://haislab.com/) (Human-Centered AI-based Learning Systems Lab)
+                * Personalized learning support using ML and NLP from an HCI perspective
+                * AI tools for digital onboarding, adaptive feedback, and reflective writing
+                * Design and evaluation of human-centered learning systems
                         
         - title: External Lecturer
           company: University of St. Gallen 
@@ -265,19 +265,11 @@ sections:
       title: Contact
       subtitle:
       text: |-
-        If you want to learn more about my work. Get in contact.
+        If you want to learn more about my work, feel free to reach out.
       # Contact (add or remove contact options as necessary)
       email: roman.rietsche@bfh.ch
       # Automatically link email and phone or display as text?
       autolink: true
-      # Email form provider
-      form:
-        provider: netlify
-        formspree:
-          id:
-        netlify:
-          # Enable CAPTCHA challenge to reduce spam?
-          captcha: false
     design:
       columns: '2'
 

--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -23,10 +23,20 @@ organizations:
 bio: My research interests include AI in Education, Human-centered Re- and Upskilling Digital Interventions.
 
 # Interests to show in About widget
-
-
+interests:
+  - Human-Centered AI Systems
+  - AI in Education
+  - Digital Coaching and Feedback
+  - Natural Language Processing for Learning
+  - Digital Interventions and Behavior Change
+  - Re- and Upskilling
 
 # Education to show in About widget
+education:
+  courses:
+    - course: Dr. oec. HSG
+      institution: University of St. Gallen
+      year: 2022
 
 
 # Social/Academic Networking
@@ -46,6 +56,9 @@ social:
   - icon: linkedin
     icon_pack: fab
     link: https://ch.linkedin.com/in/roman-rietsche-08108b151
+  - icon: orcid
+    icon_pack: ai
+    link: https://orcid.org/0000-0002-6112-1709
   # Link to a PDF of your resume/CV.
   # To use: copy your resume to `static/uploads/resume.pdf`, enable `ai` icons in `params.yaml`,
   # and uncomment the lines below.
@@ -60,18 +73,15 @@ email: 'roman.rietsche@bfh.ch'
 highlight_name: true
 ---
 
-I am a Research Professor for Information Systems and AI at Bern University of Applied Sciences, specializing at the nexus of educational technology, psychology, and human-computer interaction.
+I am a Research Professor for Information Systems and AI at Bern University of Applied Sciences and head of the [HAIS Lab](https://haislab.com/) (Human-Centered AI-based Learning Systems Lab), specializing at the nexus of educational technology, psychology, and human-computer interaction.
 
-My research follows three connected work streams: (1) developing effective information systems that embed artificial intelligence and large language models, 
-(2) designing and measuring behavior change through digital interventions, and (3) evaluating the impact of digital technologies on organizations in the context of reskilling and upskilling.
+My research follows three connected work streams: (1) developing effective information systems that embed artificial intelligence and large language models, (2) designing and measuring behavior change through digital interventions, and (3) evaluating the impact of digital technologies on organizations in the context of reskilling and upskilling.
 
-One of my key achievement is the LOOM feedback system, which has enhanced the educational experience of over 2,000 students across the United States, Germany, and Switzerland. 
+One of my key achievements is the LOOM feedback system, which has enhanced the educational experience of over 2,000 students across the United States, Germany, and Switzerland.
 
-I led the Swiss Circular Economy of Skills and Competences (SCESC) project (2022-2025), funded by a 6 million Swiss franc grant from Innosuisse.
-This project united a multidisciplinary team with researchers from EHB, EPFL, HSG-IWP, HSG-IWI, UZH and ZHAW and the implementation partner X28.
+I led the Swiss Circular Economy of Skills and Competences (SCESC) project (2022-2025), funded by a 6 million Swiss franc grant from Innosuisse. This project united a multidisciplinary team with researchers from EHB, EPFL, HSG-IWP, HSG-IWI, UZH and ZHAW and the implementation partner X28.
 
 Collaborations with industry, particularly in digital re-skilling and up-skilling, include partnerships with Siemens AG, Volkswagen AG, and Stiftung Brändi.
-
 
 {style="text-align: justify;"}
 

--- a/content/publication/bauman-2020-supporting/index.md
+++ b/content/publication/bauman-2020-supporting/index.md
@@ -9,4 +9,6 @@ date: '2020-01-01'
 publishDate: '2025-01-21T14:54:43.980885Z'
 publication_types:
 - report
+projects:
+- LOOM
 ---

--- a/content/publication/buholzer-2018-knowing/index.md
+++ b/content/publication/buholzer-2018-knowing/index.md
@@ -18,4 +18,6 @@ tags:
 - Hofstede?s cultural dimension theory
 - Massive Open Online Courses
 - Rietsche
+projects:
+- LOOM
 ---

--- a/content/publication/freise-2025-how/index.md
+++ b/content/publication/freise-2025-how/index.md
@@ -12,4 +12,6 @@ publishDate: '2026-02-20T22:12:42.305874Z'
 publication_types:
 - article-journal
 publication: '*MIS Quarterly Executive*'
+projects:
+- SCESC
 ---

--- a/content/publication/fuchs-2021-more/index.md
+++ b/content/publication/fuchs-2021-more/index.md
@@ -18,4 +18,6 @@ tags:
 - Organization
 - Rietsche
 - Simulation
+projects:
+- SCESC
 ---

--- a/content/publication/goeldi-2023-whereto/index.md
+++ b/content/publication/goeldi-2023-whereto/index.md
@@ -23,4 +23,6 @@ abstract: In an age of life-long learning, it is important that adult learners c
   two intervention types as factors and goal attainment as the dependent variable.
   Results will indicate avenues for automating skilled conversation including choice
   of technology.
+projects:
+- digital_coach
 ---

--- a/content/publication/goldi-2023-insertexpansions/index.md
+++ b/content/publication/goldi-2023-insertexpansions/index.md
@@ -25,4 +25,6 @@ tags:
 - 'FOS: Computer and information sciences'
 - H.5
 - Human-Computer Interaction (cs.HC)
+projects:
+- digital_coach
 ---

--- a/content/publication/goldi-2024-chatbot/index.md
+++ b/content/publication/goldi-2024-chatbot/index.md
@@ -10,4 +10,6 @@ publication_types:
 publication: '*International Conference on Information Systems (ICIS) 2024*'
 tags:
 - /unread
+projects:
+- digital_coach
 ---

--- a/content/publication/goldi-2024-insertexpansions/index.md
+++ b/content/publication/goldi-2024-insertexpansions/index.md
@@ -24,4 +24,6 @@ abstract: AI agents use language generation for internal reasoning and interacti
   human-chatbot interaction loop.
 tags:
 - /unread
+projects:
+- digital_coach
 ---

--- a/content/publication/goldi-2024-intelligent/index.md
+++ b/content/publication/goldi-2024-intelligent/index.md
@@ -13,4 +13,6 @@ publication: '*Proceedings of the CHI Conference on Human Factors in Computing S
 doi: 10.1145/3613904.3642549
 tags:
 - /unread
+projects:
+- LOOM
 ---

--- a/content/publication/goldi-2024-making/index.md
+++ b/content/publication/goldi-2024-making/index.md
@@ -22,4 +22,6 @@ abstract: Large Language Models (LLMs) have had major impact in society even tho
   engagement with future developments.
 tags:
 - /unread
+projects:
+- digital_coach
 ---

--- a/content/publication/goldi-2025-efficient/index.md
+++ b/content/publication/goldi-2025-efficient/index.md
@@ -11,4 +11,6 @@ publication_types:
 - paper-conference
 publication: "*CHI Conference on Human Factors in Computing Systems (CHI '25)*"
 doi: 10.1145/3706598.3713606
+projects:
+- digital_coach
 ---

--- a/content/publication/guggemos-2024-measuring/index.md
+++ b/content/publication/guggemos-2024-measuring/index.md
@@ -35,4 +35,6 @@ tags:
 - Higher Education
 - Performance Test
 - Rasch-scaling
+projects:
+- SCESC
 ---

--- a/content/publication/li-2025-spatialearn/index.md
+++ b/content/publication/li-2025-spatialearn/index.md
@@ -14,4 +14,6 @@ publication_types:
 publication: '*Proceedings of the Extended Abstracts of the CHI Conference on Human
   Factors in Computing Systems*'
 doi: 10.1145/3706599.3719742
+projects:
+- reflective_writing
 ---

--- a/content/publication/li-2025-xr/index.md
+++ b/content/publication/li-2025-xr/index.md
@@ -13,4 +13,6 @@ publication: '*Proceedings of the International Conference on Information System
 links:
 - name: URL
   url: https://aisel.aisnet.org/icis2025/imm_tech/imm_tech/5
+projects:
+- reflective_writing
 ---

--- a/content/publication/neshaei-2024-enhancing/index.md
+++ b/content/publication/neshaei-2024-enhancing/index.md
@@ -29,4 +29,6 @@ abstract: 'While writing peer reviews resembles an important task in science, ed
   in user-centered assistants.'
 tags:
 - /unread
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2017-digital/index.md
+++ b/content/publication/rietsche-2017-digital/index.md
@@ -18,4 +18,6 @@ tags:
 - HIGHER education
 - large-scale class
 - Rietsche
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2017-obvious/index.md
+++ b/content/publication/rietsche-2017-obvious/index.md
@@ -17,4 +17,6 @@ tags:
 - management education
 - Rietsche
 - Technology-Mediated Learning
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2017-twofold/index.md
+++ b/content/publication/rietsche-2017-twofold/index.md
@@ -20,4 +20,6 @@ tags:
 - large-scale class
 - Rietsche
 - Technology-Mediated Learning
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2018-design/index.md
+++ b/content/publication/rietsche-2018-design/index.md
@@ -16,4 +16,6 @@ tags:
 - Feedback_all
 - Higher_order_thinking_skills
 - Rietsche
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2019-insights/index.md
+++ b/content/publication/rietsche-2019-insights/index.md
@@ -9,4 +9,6 @@ publishDate: '2025-01-21T14:54:44.120882Z'
 publication_types:
 - chapter
 publication: '*Hawaii International Conference on System Sciences (HICSS)*'
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2020-enhancing/index.md
+++ b/content/publication/rietsche-2020-enhancing/index.md
@@ -9,4 +9,6 @@ publication_types:
 - thesis
 tags:
 - Rietsche
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2020-impact/index.md
+++ b/content/publication/rietsche-2020-impact/index.md
@@ -12,4 +12,6 @@ publication_types:
 publication: '*Handbook of Teaching with Technology in Management, Leadership, and
   Business*'
 doi: 10.4337/9781789901658.00047
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2021-does/index.md
+++ b/content/publication/rietsche-2021-does/index.md
@@ -11,4 +11,6 @@ publication_types:
 - chapter
 publication: '*Workshop on Information Technologies and Systems (WITS) in Conjunction
   with the 42nd International Conference on Information Systems (ICIS)*'
+projects:
+- SCESC
 ---

--- a/content/publication/rietsche-2022-corpus/index.md
+++ b/content/publication/rietsche-2022-corpus/index.md
@@ -28,4 +28,6 @@ abstract: Peer feedback in online education becomes increasingly important to me
   labelled the corpus and achieved an inter-annotator agreement of 0.71. With the
   help of an expert arbitrator a gold standard was created. An automatic classification
   using BERT achieved an accuracy of 75.3%.
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2022-specificity/index.md
+++ b/content/publication/rietsche-2022-specificity/index.md
@@ -32,4 +32,6 @@ abstract: With the growth of online learning through MOOCs and other educational
   specificity of sentences in feedback texts has a weak positive correlation with
   perceptions of helpfulness. This indicates that specificity is one of the ingredients
   of good feedback, and invites further investigation.
+projects:
+- LOOM
 ---

--- a/content/publication/rietsche-2025-decoding/index.md
+++ b/content/publication/rietsche-2025-decoding/index.md
@@ -15,4 +15,6 @@ doi: 10.2139/ssrn.3966150
 links:
 - name: URL
   url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3966150
+projects:
+- SCESC
 ---

--- a/content/publication/ritz-2022-unleashing/index.md
+++ b/content/publication/ritz-2022-unleashing/index.md
@@ -16,4 +16,6 @@ publication: '*Proceedings of the 17th Internationale Tagung Wirtschaftsinformat
   (WI)*'
 tags:
 - Educational Process Mining
+projects:
+- SCESC
 ---

--- a/content/publication/ritz-2023-artificial/index.md
+++ b/content/publication/ritz-2023-artificial/index.md
@@ -14,4 +14,6 @@ publication: '*Hawaii International Conference on System Sciences*'
 doi: 10.24251/HICSS.2023.020
 tags:
 - /unread
+projects:
+- SCESC
 ---

--- a/content/publication/ritz-2023-how/index.md
+++ b/content/publication/ritz-2023-how/index.md
@@ -11,4 +11,6 @@ publication_types:
 - article-journal
 publication: '*Academy of Management Learning & Education*'
 doi: 10.5465/amle.2022.0188
+projects:
+- LOOM
 ---

--- a/content/publication/ritz-2024-how/index.md
+++ b/content/publication/ritz-2024-how/index.md
@@ -31,4 +31,6 @@ abstract: In today's digital transformation era, process mining has emerged as a
   and reflect on the effectiveness of process mining for tackling procurement issues.
 tags:
 - /unread
+projects:
+- SCESC
 ---

--- a/content/publication/ritz-2024-what/index.md
+++ b/content/publication/ritz-2024-what/index.md
@@ -29,4 +29,6 @@ abstract: The fast-paced acceleration of digitalization requires extensive re-&u
   paths in intra-organizational re-&upskilling.
 tags:
 - skill_profile
+projects:
+- SCESC
 ---

--- a/content/publication/sacha-fuchs-2021/index.md
+++ b/content/publication/sacha-fuchs-2021/index.md
@@ -14,4 +14,6 @@ publication: '*Proceedings of the 16th International Conference on Wirtschaftsin
 abstract: ARRAY(0x556d1f573608)
 tags:
 - Digital Feedback;feedback;Organization;Simulation
+projects:
+- SCESC
 ---

--- a/content/publication/schmidhalter-2025-digibot/index.md
+++ b/content/publication/schmidhalter-2025-digibot/index.md
@@ -14,4 +14,6 @@ links:
 - name: URL
   url: 
     https://www.societybyte.swiss/2025/04/16/digibot-ein-personalisiertes-ki-tool-zur-selbsteinschaetzung-digitaler-kompetenzen/
+projects:
+- digit_bot
 ---

--- a/content/publication/sollner-2021-individualisierung/index.md
+++ b/content/publication/sollner-2021-individualisierung/index.md
@@ -13,4 +13,6 @@ publication_types:
 publication: '*Zeitschrift für Berufs- und Wirtschaftspädagogik*'
 tags:
 - Hybrid Intelligence
+projects:
+- SCESC
 ---

--- a/content/publication/su-2023-reviewriter/index.md
+++ b/content/publication/su-2023-reviewriter/index.md
@@ -13,4 +13,6 @@ publication_types:
 publication: '*Proceedings of the 18th Workshop on Innovative Use of NLP for Building
   Educational Applications (BEA 2023)*'
 doi: 10.18653/v1/2023.bea-1.5
+projects:
+- LOOM
 ---

--- a/content/publication/wambsganss-2019-designing/index.md
+++ b/content/publication/wambsganss-2019-designing/index.md
@@ -10,4 +10,6 @@ publication_types:
 publication: '*International Conference on Information Systems (ICIS)*'
 tags:
 - Rietsche
+projects:
+- LOOM
 ---

--- a/content/publication/wambsganss-2022-bias/index.md
+++ b/content/publication/wambsganss-2022-bias/index.md
@@ -34,4 +34,6 @@ abstract: Natural Language Processing (NLP) has become increasingly utilized to 
   of not counteracting biases in language models for educational tasks.
 tags:
 - /unread
+projects:
+- LOOM
 ---

--- a/content/publication/wambsganss-2023-unraveling/index.md
+++ b/content/publication/wambsganss-2023-unraveling/index.md
@@ -34,4 +34,6 @@ abstract: "Large Language Models (LLMs) are increasingly utilized in educational
   without LLM suggestions. Our research is therefore optimistic about the use of AI
   writing support in the classroom, showcasing a context where bias in LLMs does not
   transfer to students' responses.  Accepted as a full paper at EMNLP Findings 2023"
+projects:
+- LOOM
 ---

--- a/content/publication/wettstein-2025-dashboards/index.md
+++ b/content/publication/wettstein-2025-dashboards/index.md
@@ -12,4 +12,6 @@ publication: '*Proceedings of the International Conference on Information System
 links:
 - name: URL
   url: https://aisel.aisnet.org/icis2025/learn_curricula/learn_curricula/1
+projects:
+- reflective_writing
 ---


### PR DESCRIPTION
## Summary
- **Quick fixes:** Fixed `baseURL` (added `https://`), enabled `enableGitInfo`, added research interests + education + ORCID to author profile, replaced broken Netlify contact form with mailto
- **HAIS Lab branding:** Replaced all LAIRU references with HAIS Lab (haislab.com) in bio and experience sections
- **Navigation:** Consolidated from 8 to 7 items by merging Experience into the About section (experience timeline remains visible, just no separate nav entry)
- **Publication cross-links:** Mapped 39 of 53 publications to their corresponding projects (LOOM, SCESC, digital_coach, reflective_writing, digit_bot). 14 publications unrelated to current projects were skipped.

## Changes by file
| Category | Files | Count |
|----------|-------|-------|
| Config | `hugo.yaml`, `menus.yaml` | 2 |
| Author profile | `authors/admin/_index.md` | 1 |
| Homepage | `_index.md` | 1 |
| Publications | `content/publication/*/index.md` | 39 |
| **Total** | | **43** |

## Publication-Project Mapping
- **LOOM:** 18 publications (peer feedback, writing support, NLP for education)
- **SCESC:** 10 publications (skills, re-/upskilling, process mining, organizational learning)
- **digital_coach:** 6 publications (coaching chatbots, LLM agents, non-factive reasoning)
- **reflective_writing:** 3 publications (XR learning, dashboards, reflective writing)
- **digit_bot:** 1 publication (DigiBot self-assessment tool)
- **Skipped:** 14 (quantum computing, presentation slides, general literature reviews, early work)

## Test plan
- [ ] Verify homepage renders correctly with experience block below bio
- [ ] Check that ORCID icon appears in social links
- [ ] Confirm contact section shows email without broken form
- [ ] Visit a project page and verify related publications appear
- [ ] Check navigation bar has 7 items (no Experience)

🤖 Generated with [Claude Code](https://claude.com/claude-code)